### PR TITLE
Added the ability to import multiple animations for a model at a time

### DIFF
--- a/Metanoia/Rendering/ModelViewer.Designer.cs
+++ b/Metanoia/Rendering/ModelViewer.Designer.cs
@@ -114,7 +114,7 @@ namespace Metanoia.Rendering
             // 
             this.importAnimationToolStripMenuItem.Name = "importAnimationToolStripMenuItem";
             this.importAnimationToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
-            this.importAnimationToolStripMenuItem.Text = "Import Animation";
+            this.importAnimationToolStripMenuItem.Text = "Import Animation(s)";
             this.importAnimationToolStripMenuItem.Click += new System.EventHandler(this.importAnimationToolStripMenuItem_Click);
             // 
             // exportButton

--- a/Metanoia/Rendering/ModelViewer.cs
+++ b/Metanoia/Rendering/ModelViewer.cs
@@ -499,14 +499,19 @@ namespace Metanoia.Rendering
         {
             using (OpenFileDialog d = new OpenFileDialog())
             {
+                d.Multiselect = true;
                 d.Filter = FormatManager.Instance.GetAnimationExtensionFilter();
-                
+
                 if (d.ShowDialog() == DialogResult.OK)
                 {
-                    if(FormatManager.Instance.Open(new FileItem(d.FileName)) is IAnimationFormat anim)
+                    foreach (String filename in d.FileNames)
                     {
-                        AddAnimation(anim.ToGenericAnimation());
+                        if (FormatManager.Instance.Open(new FileItem(filename)) is IAnimationFormat anim)
+                        {
+                            AddAnimation(anim.ToGenericAnimation());
+                        }
                     }
+
                 }
             }
         }


### PR DESCRIPTION
Set it so `OpenFileDialog` supported opening multiple files at a time. This makes it easier to import multiple animations for a model instead of having to open each animation one at a time.

Updated the prompt to say Animation(s) to signify you are able to open an animation or animations.